### PR TITLE
Update SlnTools.fs

### DIFF
--- a/SlnTools/SlnTools.fs
+++ b/SlnTools/SlnTools.fs
@@ -86,7 +86,7 @@ with
 let getTransitiveClosure (projects : seq<string>) =
     // TODO replace with `dotnet list reference`
     let p2pRegex = Regex("""<\s*ProjectReference\s+Include\s*=\s*"(.+)"\s*/?>""")
-    let getProjectReferences proj =
+    let getProjectReferences (proj: string) =
         let projectDir = Path.GetDirectoryName proj
         let xml = File.ReadAllText proj
 


### PR DESCRIPTION
Fix overload warn inside function, when running on Span-enabled runtimes.